### PR TITLE
fix: iOS26兼容，修复iOS26布局错乱的问题。

### DIFF
--- a/TYCyclePagerViewDemo/TYCyclePagerView/TYCyclePagerView.m
+++ b/TYCyclePagerViewDemo/TYCyclePagerView/TYCyclePagerView.m
@@ -600,7 +600,7 @@ NS_INLINE TYIndexSection TYMakeIndexSection(NSInteger index, NSInteger section) 
         dispatch_async(dispatch_get_main_queue(), ^{
             if (weakSelf.numberOfItems > 0 && !weakSelf.didLayout) {
                 weakSelf.didLayout = YES;
-                [self setNeedUpdateLayout];
+                [weakSelf setNeedUpdateLayout];
             }
         });
     }

--- a/TYCyclePagerViewDemo/TYCyclePagerView/TYCyclePagerView.m
+++ b/TYCyclePagerViewDemo/TYCyclePagerView/TYCyclePagerView.m
@@ -593,6 +593,16 @@ NS_INLINE TYIndexSection TYMakeIndexSection(NSInteger index, NSInteger section) 
     if ((_indexSection.section < 0 || needUpdateLayout) && (_numberOfItems > 0 || _didReloadData)) {
         _didLayout = YES;
         [self setNeedUpdateLayout];
+    } else if (_numberOfItems == 0 && !_didLayout) {
+        // iOS26兼容，修复iOS26布局错乱的问题：
+        //针对numberOfItems为0情况下导致布局更新失败的处理，延迟到下一个runloop再布局更新，此时numberOfItems已加载完成
+        __weak typeof(self) weakSelf = self;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (weakSelf.numberOfItems > 0 && !weakSelf.didLayout) {
+                weakSelf.didLayout = YES;
+                [self setNeedUpdateLayout];
+            }
+        });
     }
 }
 


### PR DESCRIPTION
针对numberOfItems为0情况下导致布局更新失败的处理，延迟到下一个runloop再布局更新，此时numberOfItems已加载完成。
已经过测试验证，iOS26 及 iOS18 均运行正常。
修复之前：
<img width="220" height="478" alt="screenshot-1" src="https://github.com/user-attachments/assets/637a60e5-adfb-43fb-a6c8-5baea4c36298" />
修复之后：
<img width="220" height="478" alt="screenshot-1" src="https://github.com/user-attachments/assets/d9edde9f-5ac8-4ba3-b317-c5020bec050a" />